### PR TITLE
Enable to pass database url directly for config

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ db = mongo.setup(config);
 db.add('users');
 ```
 
+Basically, wrapper `setup` method constructs connection url from `config` object,
+according following format(if no host is given, `localhost` is used):
+
+```
+mongodb://<username>:<password>@<hosts[0].name>:<hosts[0].port>,<hosts[1].name>:<hosts[1].port>,(...)/<database>?querystring(<options>)
+```
+
+However if you set `config.url` directly, `setup` just uses the url rather creating another url.
+
 ### Query
 
 ```js

--- a/index.js
+++ b/index.js
@@ -115,23 +115,31 @@ DbWrapper.prototype.close = function() {
 };
 
 var setup = function(config) {
-  var url = 'mongodb://';
-  if (config.username) url += config.username + ':' + config.password + '@';
-  if (config.hosts) {
-    config.hosts.forEach(function(host, i) {
-      if (i != 0) url += ',';
-      url += host.name + ':' + (host.port || 27017);
-    });
+  var url = '';
+  if(config.uri || config.url) {
+    // if full url(or uri) string is given, use it.
+    url = config.uri || config.url;
   } else {
-    url += 'localhost';
+    // construct url string manually.
+    url = 'mongodb://';
+    if (config.username) url += config.username + ':' + config.password + '@';
+    if (config.hosts) {
+      config.hosts.forEach(function(host, i) {
+        if (i != 0) url += ',';
+        url += host.name + ':' + (host.port || 27017);
+      });
+    } else {
+      url += 'localhost';
+    }
+    url += '/' + (config.database + '');
+    if (config.options) {
+      Object.keys(config.options).forEach(function(option, i) {
+        url += i == 0 ? '?' : '&';
+        url += option + '=' + config.options[option];
+      });
+    };
   }
-  url += '/' + (config.database + '');
-  if (config.options) {
-    Object.keys(config.options).forEach(function(option, i) {
-      url += i == 0 ? '?' : '&';
-      url += option + '=' + config.options[option];
-    });
-  };
+  
   wrapper.db = new DbWrapper(url, config);
   return wrapper.db;
 };


### PR DESCRIPTION
Someone like me wouldn't like the way `.setup` examines and make the query string. I got a full url string that have been used couple of times in my project(e.g. connect-mongodb-session) and I don't want to have a separated setting object.

Or, you could split the setup method to have a helper method that simply converts object into url string for convenience.
